### PR TITLE
golang-pam: support building on linux.

### DIFF
--- a/golang-pam.c
+++ b/golang-pam.c
@@ -1,4 +1,6 @@
+#ifdef __APPLE__
 #include <security/pam_types.h>
+#endif
 #include <security/pam_appl.h>
 #include <stdlib.h>
 #include <string.h>

--- a/golang-pam.c
+++ b/golang-pam.c
@@ -56,14 +56,14 @@ int gopam_conv(int num_msg, const struct pam_message **msg, struct pam_response 
 
 /* This allocates a new pam_conv struct and fills in its fields:
    The conv function pointer always points to the universal gopam_conv.
-   The appdata_ptr will be set to the incoming void* argument, which
-   is always a Go-side *pam.conversation whose handler was given
-   to pam.Start(). */
-struct pam_conv* make_gopam_conv(void *goconv)
+   appdata_ptr should be set to the *pam.conversation returned by
+   pam.Start(). It needs to be set by whatever calls this becuase it'll
+   be a Go-side pointer and go1.6 (https://github.com/golang/go/issues/12416)
+   prevents intermingling pointers like that. */
+struct pam_conv* make_gopam_conv()
 {
     struct pam_conv* conv = (struct pam_conv*)malloc(sizeof(struct pam_conv));
     conv->conv = gopam_conv;
-    conv->appdata_ptr = goconv;
     return conv;
 }
 

--- a/golang-pam.h
+++ b/golang-pam.h
@@ -7,5 +7,5 @@ typedef struct {
 } get_item_result;
 
 get_item_result pam_get_item_string(pam_handle_t *handle, int type);
-struct pam_conv* make_gopam_conv(void *goconv);
+struct pam_conv* make_gopam_conv();
 

--- a/pam.go
+++ b/pam.go
@@ -3,11 +3,11 @@
 package pam
 
 import (
-    //#include "golang-pam.h"
-    //#cgo LDFLAGS: -lpam
-    "C"
-    "unsafe"
-    "strings"
+	//#include "golang-pam.h"
+	//#cgo LDFLAGS: -lpam
+	"C"
+	"strings"
+	"unsafe"
 )
 
 // Objects implementing the ConversationHandler interface can
@@ -17,51 +17,52 @@ import (
 // TEXT_INFO) and a message string.  It is expected to return
 // a response string and a bool indicating success or failure.
 type ConversationHandler interface {
-    RespondPAM(msg_style int, msg string) (string,bool)
+	RespondPAM(msg_style int, msg string) (string, bool)
 }
 
 // ResponseFunc is an adapter to allow the use of ordinary
 // functions as conversation callbacks.  ResponseFunc(f) is
 // a ConversationHandler that calls f, where f must have
 // the signature func(int,string)(string,bool).
-type ResponseFunc func(int,string) (string,bool)
-func (f ResponseFunc) RespondPAM(style int, msg string) (string,bool) {
-    return f(style,msg)
+type ResponseFunc func(int, string) (string, bool)
+
+func (f ResponseFunc) RespondPAM(style int, msg string) (string, bool) {
+	return f(style, msg)
 }
 
 // Internal conversation structure
 type conversation struct {
-    handler ConversationHandler
-    cconv *C.struct_pam_conv
+	handler ConversationHandler
+	cconv   *C.struct_pam_conv
 }
 
 // Cosntructs a new conversation object with a given handler and a newly
 // allocated pam_conv struct that uses this object as its appdata_ptr
 func newConversation(handler ConversationHandler) *conversation {
-    conv := &conversation{}
-    conv.handler = handler
-    conv.cconv = C.make_gopam_conv()
-    conv.cconv.appdata_ptr = unsafe.Pointer(conv)
-    return conv
+	conv := &conversation{}
+	conv.handler = handler
+	conv.cconv = C.make_gopam_conv()
+	conv.cconv.appdata_ptr = unsafe.Pointer(conv)
+	return conv
 }
 
 //export goPAMConv
 // Go-side function for processing a single conversational message.  Ultimately
 // this calls the associated ConversationHandler's ResponsePAM callback with data
 // coming in from a C-side call.
-func goPAMConv(msg_style C.int, msg *C.char, appdata unsafe.Pointer) (*C.char,int)  {
-    conv := (*conversation)(appdata)
-    resp,ok := conv.handler.RespondPAM(int(msg_style), C.GoString(msg))
-    if ok {
-        return C.CString(resp),SUCCESS
-    }
-    return nil,CONV_ERR
+func goPAMConv(msg_style C.int, msg *C.char, appdata unsafe.Pointer) (*C.char, int) {
+	conv := (*conversation)(appdata)
+	resp, ok := conv.handler.RespondPAM(int(msg_style), C.GoString(msg))
+	if ok {
+		return C.CString(resp), SUCCESS
+	}
+	return nil, CONV_ERR
 }
 
 // Transaction is the application's handle for a single PAM transaction.
 type Transaction struct {
-    handle *C.pam_handle_t
-    conv *conversation
+	handle *C.pam_handle_t
+	conv   *conversation
 }
 
 // Start initiates a new PAM transaction.  serviceName is treated identically
@@ -74,22 +75,22 @@ type Transaction struct {
 //
 // The returned status int may be ABORT, BUF_ERR, SUCCESS, or SYSTEM_ERR, as per
 // the official PAM documentation.
-func Start(serviceName, user string, handler ConversationHandler) (*Transaction,int) {
-    t := &Transaction{}
-    t.conv = newConversation(handler)
-    var status C.int
-    if len(user) == 0 {
-        status = C.pam_start(C.CString(serviceName), nil, t.conv.cconv, &t.handle)
-    } else {
-        status = C.pam_start(C.CString(serviceName), C.CString(user), t.conv.cconv, &t.handle)
-    }
+func Start(serviceName, user string, handler ConversationHandler) (*Transaction, int) {
+	t := &Transaction{}
+	t.conv = newConversation(handler)
+	var status C.int
+	if len(user) == 0 {
+		status = C.pam_start(C.CString(serviceName), nil, t.conv.cconv, &t.handle)
+	} else {
+		status = C.pam_start(C.CString(serviceName), C.CString(user), t.conv.cconv, &t.handle)
+	}
 
-    if status != SUCCESS {
-        C.free(unsafe.Pointer(t.conv.cconv))
-        return nil,int(status)
-    }
+	if status != SUCCESS {
+		C.free(unsafe.Pointer(t.conv.cconv))
+		return nil, int(status)
+	}
 
-    return t, int(status)
+	return t, int(status)
 }
 
 // Ends a PAM transaction.  From Linux-PAM documentation: "The [status] argument
@@ -100,8 +101,8 @@ func Start(serviceName, user string, handler ConversationHandler) (*Transaction,
 // This *must* be called on any Transaction successfully returned by Start() or
 // you will leak memory.
 func (t *Transaction) End(status int) {
-    C.pam_end(t.handle, C.int(status))
-    C.free(unsafe.Pointer(t.conv.cconv))
+	C.pam_end(t.handle, C.int(status))
+	C.free(unsafe.Pointer(t.conv.cconv))
 }
 
 // Sets a PAM informational item.  Legal values of itemType are listed here (excluding Linux extensions):
@@ -111,71 +112,75 @@ func (t *Transaction) End(status int) {
 // the CONV item type is also not supported in order to simplify the Go API (and due to
 // the fact that it is completely unnecessary).
 func (t *Transaction) SetItem(itemType int, item string) int {
-    if itemType == CONV { return BAD_ITEM }
-    cs := unsafe.Pointer(C.CString(item))
-    defer C.free(cs)
-    return int(C.pam_set_item(t.handle, C.int(itemType), cs))
+	if itemType == CONV {
+		return BAD_ITEM
+	}
+	cs := unsafe.Pointer(C.CString(item))
+	defer C.free(cs)
+	return int(C.pam_set_item(t.handle, C.int(itemType), cs))
 }
 
 // Gets a PAM item.  Legal values of itemType are as specified by the documentation of SetItem.
-func (t *Transaction) GetItem(itemType int) (string,int) {
-    if itemType == CONV { return "",BAD_ITEM }
-    result := C.pam_get_item_string(t.handle, C.int(itemType))
-    return C.GoString(result.str),int(result.status)
+func (t *Transaction) GetItem(itemType int) (string, int) {
+	if itemType == CONV {
+		return "", BAD_ITEM
+	}
+	result := C.pam_get_item_string(t.handle, C.int(itemType))
+	return C.GoString(result.str), int(result.status)
 }
 
 // Error returns a PAM error string from a PAM error code
 func (t *Transaction) Error(errnum int) string {
-    return C.GoString(C.pam_strerror(t.handle, C.int(errnum)))
+	return C.GoString(C.pam_strerror(t.handle, C.int(errnum)))
 }
 
 // pam_authenticate
 func (t *Transaction) Authenticate(flags int) int {
-    return int(C.pam_authenticate(t.handle, C.int(flags)))
+	return int(C.pam_authenticate(t.handle, C.int(flags)))
 }
 
 // pam_setcred
-func (t* Transaction) SetCred(flags int) int {
-    return int(C.pam_setcred(t.handle, C.int(flags)))
+func (t *Transaction) SetCred(flags int) int {
+	return int(C.pam_setcred(t.handle, C.int(flags)))
 }
 
 // pam_acctmgmt
-func (t* Transaction) AcctMgmt(flags int) int {
-    return int(C.pam_acct_mgmt(t.handle, C.int(flags)))
+func (t *Transaction) AcctMgmt(flags int) int {
+	return int(C.pam_acct_mgmt(t.handle, C.int(flags)))
 }
 
 // pam_chauthtok
-func (t* Transaction) ChangeAuthTok(flags int) int {
-    return int(C.pam_chauthtok(t.handle, C.int(flags)))
+func (t *Transaction) ChangeAuthTok(flags int) int {
+	return int(C.pam_chauthtok(t.handle, C.int(flags)))
 }
 
 // pam_open_session
-func (t* Transaction) OpenSession(flags int) int {
-    return int(C.pam_open_session(t.handle, C.int(flags)))
+func (t *Transaction) OpenSession(flags int) int {
+	return int(C.pam_open_session(t.handle, C.int(flags)))
 }
 
 // pam_close_session
-func (t* Transaction) CloseSession(flags int) int {
-    return int(C.pam_close_session(t.handle, C.int(flags)))
+func (t *Transaction) CloseSession(flags int) int {
+	return int(C.pam_close_session(t.handle, C.int(flags)))
 }
 
 // pam_putenv
-func (t* Transaction) PutEnv(nameval string) int {
-    cs := C.CString(nameval)
-    defer C.free(unsafe.Pointer(cs))
-    return int(C.pam_putenv(t.handle, cs))
+func (t *Transaction) PutEnv(nameval string) int {
+	cs := C.CString(nameval)
+	defer C.free(unsafe.Pointer(cs))
+	return int(C.pam_putenv(t.handle, cs))
 }
 
 // pam_getenv.  Returns an additional argument indicating
 // the actual existence of the given environment variable.
-func (t* Transaction) GetEnv(name string) (string,bool) {
-    cs := C.CString(name)
-    defer C.free(unsafe.Pointer(cs))
-    value := C.pam_getenv(t.handle, cs)
-    if value != nil {
-        return C.GoString(value),true
-    }
-    return "",false
+func (t *Transaction) GetEnv(name string) (string, bool) {
+	cs := C.CString(name)
+	defer C.free(unsafe.Pointer(cs))
+	value := C.pam_getenv(t.handle, cs)
+	if value != nil {
+		return C.GoString(value), true
+	}
+	return "", false
 }
 
 // GetEnvList internally calls pam_getenvlist and then uses some very
@@ -183,16 +188,15 @@ func (t* Transaction) GetEnv(name string) (string,bool) {
 // it into a map[string]string.  This call may be safe, but it hasn't
 // been tested on enough platforms/architectures/PAM-implementations to
 // be sure.
-func (t* Transaction) GetEnvList() map[string]string {
-    env := make(map[string]string)
-    list := (uintptr)(unsafe.Pointer(C.pam_getenvlist(t.handle)))
-    for *(*uintptr)(unsafe.Pointer(list)) != 0 {
-        entry := *(*uintptr)(unsafe.Pointer(list))
-        nameval := C.GoString((*C.char)(unsafe.Pointer(entry)))
-        chunks := strings.SplitN(nameval, "=", 2)
-        env[chunks[0]] = chunks[1]
-        list += (uintptr)(unsafe.Sizeof(list))
-    }
-    return env
+func (t *Transaction) GetEnvList() map[string]string {
+	env := make(map[string]string)
+	list := (uintptr)(unsafe.Pointer(C.pam_getenvlist(t.handle)))
+	for *(*uintptr)(unsafe.Pointer(list)) != 0 {
+		entry := *(*uintptr)(unsafe.Pointer(list))
+		nameval := C.GoString((*C.char)(unsafe.Pointer(entry)))
+		chunks := strings.SplitN(nameval, "=", 2)
+		env[chunks[0]] = chunks[1]
+		list += (uintptr)(unsafe.Sizeof(list))
+	}
+	return env
 }
-

--- a/pam.go
+++ b/pam.go
@@ -40,7 +40,8 @@ type conversation struct {
 func newConversation(handler ConversationHandler) *conversation {
     conv := &conversation{}
     conv.handler = handler
-    conv.cconv = C.make_gopam_conv(unsafe.Pointer(conv))
+    conv.cconv = C.make_gopam_conv()
+    conv.cconv.appdata_ptr = unsafe.Pointer(conv)
     return conv
 }
 


### PR DESCRIPTION
on linux, pam_types.h is installed as _pam_types.h and it doesn't seem
to be required to build.
